### PR TITLE
Update actions/cache version for node 20 support

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ runs:
 
     - name: cache volta+node+yarn
       id: cache
-      uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7  # v3.0.11
+      uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
       with:
         path: ${{ steps.vars.outputs.volta-dir }}
         key: ${{ steps.vars.outputs.cache-key }}
@@ -26,7 +26,7 @@ runs:
       run: python3 -uS ${{ github.action_path }}/bin/setup-volta yarn-cache-dir
 
     - name: cache yarn
-      uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7  # v3.0.11
+      uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
       with:
         path: ${{ steps.yarn.outputs.cache-dir }}
         key: ${{ steps.vars.outputs.cache-key }}-${{ hashFiles('**/yarn.lock') }}


### PR DESCRIPTION
Bumping actions/cache version in order to support node20 as node16 is deprecated.